### PR TITLE
Coinjointimer script fix + documentation improvement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To randomize the time that Wasabi starts and stops to coinjoin.
 #### How to use
 `./coinjointimer.sh walletName="WALLET" password="PASSWORD" hours=12 maxCoinjoinRounds=6`
 
-`walletName` is the wallets name, `password` is the wallets password, `hours` is randomized wait time period based on input value => hours +-20%, `maxCoinjoinRounds` the number of coinjoins that should happen. In the above example, one coinjoin should happen every 12 hours, and in total 6 coinjoins, so the ceremony should be concluded in 72 hours.
+`walletName` is the wallets name, `password` is the wallets password, `hours` is wait time period randomized by +-20%, `maxCoinjoinRounds` the number of coinjoins that should happen. In the above example, one coinjoin should happen every 12 hours, and in total 6 coinjoins, so the ceremony should be concluded in 72 hours.
 
 `Example of hours argument usage`: `hours=100` - first and every other conjoin will start between `80-120`hours.
 Value of hours between coinjoins is generated each time separately, so wait hour time for first coinjoin in this example should be randomly generated let say to `115` hours, for second coinjoin `81` for third `97` and so on.

--- a/README.md
+++ b/README.md
@@ -29,4 +29,7 @@ To randomize the time that Wasabi starts and stops to coinjoin.
 #### How to use
 `./coinjointimer.sh walletName="WALLET" password="PASSWORD" hours=12 maxCoinjoinRounds=6`
 
-`walletName` is the wallets name, `password` is the wallets password, `hours` the time in which one coinjoin should happen, `maxCoinjoinRounds` the number of coinjoins that should happen. In the above example, one coinjoin should happen every 12 hours, and in total 6 coinjoins, so the ceremony should be concluded in 72 hours.
+`walletName` is the wallets name, `password` is the wallets password, `hours` is randomized wait time period based on input value => hours +-20%, `maxCoinjoinRounds` the number of coinjoins that should happen. In the above example, one coinjoin should happen every 12 hours, and in total 6 coinjoins, so the ceremony should be concluded in 72 hours.
+
+`Example of hours argument usage`: `hours=100` - first and every other conjoin will start between `80-120`hours.
+Value of hours between coinjoins is generated each time separately, so wait hour time for first coinjoin in this example should be randomly generated let say to `115` hours, for second coinjoin `81` for third `97` and so on.

--- a/coinjointimer.sh
+++ b/coinjointimer.sh
@@ -65,6 +65,16 @@ i=0
 while [ $i -lt $maxCoinjoinRounds ]
 do
 	coinjoin
+	
+	 ((i++))
+    	
+    	if [ $i -eq $maxCoinjoinRounds ];
+      then
+      
+      	echo "Last (of $maxCoinjoinRounds) conjoins successfully finished"
+      
+      exit 0
+      fi
 
 	hoursToWait=$[secondsToWait / 3600]
 
@@ -74,11 +84,7 @@ do
 
 	sleep $secondsToWait 
 
-	((i++))
-
 	echo "Ready for next coinjoin"
 
 done
-
-	echo "Last (of $maxCoinjoinRounds) conjoins successfully finished"
 	


### PR DESCRIPTION
Removing waiting time after last coinjoin before last `conjoins successfully finished` coinjointimer cript log message.
Documentation of hour parameter of coinjointimer script improved.